### PR TITLE
Adding description.jardesc

### DIFF
--- a/CTexample/src/CTsink2.java
+++ b/CTexample/src/CTsink2.java
@@ -3,6 +3,7 @@ import cycronix.ctlib.*;
  
 /**
  * CloudTurbine demo sink
+ * JPW tweak
  * <p>
  * @author Matt Miller (MJM), Cycronix
  * @version 2014/03/10

--- a/CTexample/src/CTsink2.java
+++ b/CTexample/src/CTsink2.java
@@ -3,7 +3,6 @@ import cycronix.ctlib.*;
  
 /**
  * CloudTurbine demo sink
- * JPW tweak
  * <p>
  * @author Matt Miller (MJM), Cycronix
  * @version 2014/03/10

--- a/CTlib/lib/description.jardesc
+++ b/CTlib/lib/description.jardesc
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<jardesc>
+    <jar path="CTlib/lib/CTlib.jar"/>
+    <options buildIfNeeded="true" compress="true" descriptionLocation="/CTlib/lib/description.jardesc" exportErrors="false" exportWarnings="true" includeDirectoryEntries="false" overwrite="false" saveDescription="true" storeRefactorings="false" useSourceFolders="false"/>
+    <storedRefactorings deprecationInfo="true" structuralOnly="false"/>
+    <selectedProjects/>
+    <manifest generateManifest="true" manifestLocation="" manifestVersion="1.0" reuseManifest="false" saveManifest="false" usesManifest="true">
+        <sealing sealJar="false">
+            <packagesToSeal/>
+            <packagesToUnSeal/>
+        </sealing>
+    </manifest>
+    <selectedElements exportClassFiles="true" exportJavaFiles="false" exportOutputFolder="false">
+        <javaElement handleIdentifier="=CTlib/src"/>
+    </selectedElements>
+</jardesc>


### PR DESCRIPTION
description.jardesc tells Eclipse how to build a JAR file; in this case, CTlib/lib/CTlib.jar

From Eclipse, user can either double-click on description.jardesc to be guided through the JAR creation wizard, or else simply right click on description.jardesc and select "Create JAR" from the popup menu.

@mjm-cycronix Potential issues for discussion

1. I've put description.jardesc in the lib folder; alternatively, it could be located at the top level of the Eclipse project, right alongside build.xml

2. A downside of ".jardesc" is that the JAR file can't be deployed to multiple places.  CTlib.jar is used in the CTandroidAV and CTandroidACL Eclipse projects; it _might_ be nice to have the CTlib.jar files in these projects automatically updated when a new CTlib.jar is available, but this isn't possible when using a .jardesc.  An Ant build file for creating CTlib.jar could be written which specifies multiple deployment locations, but if we switch from description.jardesc to using such an Ant file we'd have to standardize where the *.class files are located (a nice thing about description.jardesc is that it seems to automatically build and put together the class files behind the scenes).
