### PR TITLE
Remove dependencies from top-level build.gradle

### DIFF
--- a/CloudTurbineAndroid/build.gradle
+++ b/CloudTurbineAndroid/build.gradle
@@ -15,10 +15,3 @@ buildscript {
     }
 }
 
-// Here are the projects to build
-dependencies {
-    project(":CTandroidACL")
-    project(":CTandroidAV")
-    project(":CTAserver")
-}
-


### PR DESCRIPTION
I previously thought that all of the Android projects needed to be
listed in the top level build.gradle file in a "dependencies" section;
but this isn't actually needed.
