### PR TITLE
tweaks to .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ bin/
 build/
 .gradle/
 .settings/
+JavaDoc/
 

--- a/CloudTurbine/.gitignore
+++ b/CloudTurbine/.gitignore
@@ -1,0 +1,2 @@
+Distribute/
+

--- a/CloudTurbineAndroid/.gitignore
+++ b/CloudTurbineAndroid/.gitignore
@@ -1,4 +1,6 @@
 local.properties
 .idea/
 *.iml
+Common/CTlib.jar
+Common/CTserver.jar
 


### PR DESCRIPTION
Change .gitignore files to have Git ignore our more dynamic JAR and Javadoc files.  Still need to delete JAR and Javadoc files from a few directories, might be best for Matt to do that in order to avoid conflicts with file versions.
