### PR TITLE
Minor changes to replace << (which will be deprecated) with doLast

### DIFF
--- a/AndroidCode/build.gradle
+++ b/AndroidCode/build.gradle
@@ -98,7 +98,7 @@ subprojects {
         dirObj.deleteDir()
     }
     
-    build << {
+    build.doLast {
     	task -> println "Built $task.project.name"
     }
     

--- a/JavaCode/CTlib/build.gradle
+++ b/JavaCode/CTlib/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 // Copy JAR file to the AndroidCode folder
-build << {
+build.doLast {
 	String fromLoc = "${buildDir}/libs/CTlib.jar"
 	String toLoc = "../../AndroidCode/Common"
 	println "Copy library from " + fromLoc + " to " + toLoc

--- a/JavaCode/build.gradle
+++ b/JavaCode/build.gradle
@@ -57,8 +57,8 @@ subprojects {
     compileJava.mustRunAfter clean
     
     // Copy the JAR file to a top level "Distribute" folder; do this last 
-    // (specified by "<<") so we make sure to get the newly built JAR file
-    build << {
+    // so we make sure to get the newly built JAR file
+    build.doLast {
     	task -> println "Built $task.project.name"
     	String fromLoc = "${buildDir}/libs/" + project.name + ".jar"
     	String toLoc = "../Distribute"


### PR DESCRIPTION
The "<<" operator will be deprecated; therefore, I've replaced instances of << with the "doLast" command (these are equivalent).  This change is a simple one-to-one replacement.

After updating your local code, remember to do a refresh on Gradle in Eclipse to have the updated build files integrated.