### PR TITLE
Updated CTscreencap

### DIFF
--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/AudiocapTask.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/AudiocapTask.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Cycronix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.ctscreencap;
 
@@ -42,9 +39,9 @@ public class AudiocapTask {
 	CTwriter ctw_audio=null;
 	
 	// constructor
-	public AudiocapTask(String outputFolder) {
+	public AudiocapTask(String dstFolder) {
 		try {
-			ctw_audio = new CTwriter(outputFolder+"/CTaudio");
+			ctw_audio = new CTwriter(dstFolder);
 			ctw_audio.setBlockMode(true,true);		// pack, zip
 			ctw_audio.autoFlush(0);					// no autoflush
 			//	 ctw.autoSegment(0);			// no segments

--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/CTscreencap.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/CTscreencap.java
@@ -1,28 +1,36 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.ctscreencap;
 
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -35,6 +43,14 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 
 import org.apache.commons.cli.CommandLine;
@@ -77,9 +93,10 @@ import cycronix.ctlib.CTinfo;
  *    probably involve writing native OS-specific code.
  * 
  * @author John P. Wilson
+ * @version 01/26/2017
  *
  */
-public class CTscreencap extends TimerTask {
+public class CTscreencap extends TimerTask implements ActionListener {
 	
 	// Encoded byte array of the cursor image data from "Cursor_NoShadow.png"
 	public static String encoded_cursor_noshadow = "iVBORw0KGgoAAAANSUhEUgAAABQAAAAgCAYAAAASYli2AAACa0lEQVR42q2WT2jSYRjHR+QtwX/oREVBhIYxGzJNyEOIXTp0yr8HYTRQlNz8O6dgoJ4FT2ZeJAw8CEkdhBYMFHfypLBDsZ3CUYcijErn7+l9BCPZbJrvF97L+/D7/N7neZ8/74rVan27QlngdDpfUQWKxWJwuVwvqQG73S6srq7C1tbWMyrAwWAAnU4HhEIhbG9vZ6kAUe12GwQCAbjd7jQVIOro6Ah4PB7j9XpjVICow8ND4HA4jM/ne0IFiKrX68DlcpmdnZ3HVICoWq02dn93d9dBBYiqVCrA5/NHoVDoIRUgqlQqYUoh9D4VICqfz2NFnUej0btUgKhsNgsymWy4t7e3SQWIymQyoFAofsVisVtUgKh4PA4qlepHIpFQUQEyDAOBQADW1ta+E7hsaeAESmoe1tfXvxH3RUsDUaPRCPsoaLXaL8lkkrcQ8OTkBFqt1oXVaDRAo9GAXq//TKA35gaSmgY2m81g3GYti8Xybm7g8fHxuK7JKTj/ldgHBwdweno6tWcymXBMPF8YWK1WgcVigd/vv7CvVqv7CwHL5TJ2F4bMlhzph9Dv9//YhsMhSKVSjKdrLmCxWMSZMiJJ+wgNBoPhU6FQmDplKpUCs9n8/kpgLpcDkUh0HgwGH0wMHo/nKaYEJvFEvV4PbxvLTzkTmE6nQSKRDMPh8L2/DeRGr2N3aTabU6e02Wxgt9tfzwTK5fJBJBK5c5mRfPjG4XBMxZEML1AqlT8vpaFhf3//9qy/YUdBF8/OzsZze2NjA9fXmd2bFPbNq9KAXMIHnU43noKkdl+QUFxb6mmBaWI0Gj/+y5OJfgOMmgOC3DbusQAAAABJRU5ErkJggg==";
@@ -87,25 +104,30 @@ public class CTscreencap extends TimerTask {
 	public final static double DEFAULT_FPS = 5.0;         // default frames/sec
 	public final static double AUTO_FLUSH_DEFAULT = 1.0;  // default auto-flush in seconds
 	
-	public long capturePeriodMillis;           // period between screen captures (msec)
-	public String outputFolder = ".";          // location of output files
-	public String sourceName = "CTscreencap";  // output source name
-	public String channelName = "image.jpg";   // output channel name
-	public boolean bZipMode = true;            // output ZIP files?
-	public long autoFlushMillis;               // flush interval (msec)
-	public boolean bDebugMode = false;         // run CT in debug mode?
-	public boolean bShutdown = false;          // is it time to shut down?
-	public boolean bIncludeMouseCursor = true; // include the mouse cursor in the screencap image?
-	public BufferedImage cursor_img = null;    // cursor to add to the screen captures
-	public CTwriter ctw = null;                // CloudTurbine writer object
-	public Timer timerObj = null;              // Timer object
-	public float imageQuality = 0.70f;         // Image quality; 0.00 - 1.00; higher numbers correlate to better quality/less compression
-	public Rectangle regionToCapture = null;   // The region to capture
-	public BlockingQueue<byte[]> queue = null; // Queue of byte arrays containing screen captures to be sent to CT
+	public long capturePeriodMillis;			// period between screen captures (msec)
+	public String outputFolder = ".";			// location of output files
+	public String sourceName = "CTscreencap";	// output source name
+	public String channelName = "image.jpg";	// output channel name
+	public boolean bZipMode = true;				// output ZIP files?
+	public long autoFlushMillis;				// flush interval (msec)
+	public boolean bDebugMode = false;			// run CT in debug mode?
+	public boolean bShutdown = false;			// is it time to shut down?
+	public boolean bIncludeMouseCursor = true;	// include the mouse cursor in the screencap image?
+	public BufferedImage cursor_img = null;		// cursor to add to the screen captures
+	public CTwriter ctw = null;					// CloudTurbine writer object
+	public Timer timerObj = null;				// Timer object
+	public float imageQuality = 0.70f;			// Image quality; 0.00 - 1.00; higher numbers correlate to better quality/less compression
+	public Rectangle regionToCapture = null;	// The region to capture
+	public BlockingQueue<byte[]> queue = null; 	// Queue of byte arrays containing screen captures to be sent to CT
 	public boolean bChangeDetect = false;		// detect and record only images that change (more CPU, less storage)
 	public boolean bAudioCapture = false;		// record synchronous audio?
+	public boolean bFullScreen = false;			// automatically capture the full screen?
 	
-	private AudiocapTask audioTask=null;		// audio-capture task (optional)
+	private AudiocapTask audioTask = null;		// audio-capture task (optional)
+	
+	private JFrame guiFrame = null;				// JFrame which contains translucent panel which defines the capture region
+	private JPanel controlsPanel = null;		// Panel which contains UI controls
+	private JPanel capturePanel = null;			// Translucent panel which defines the region to capture
 	
 	//
 	// main() function; create an instance of CTscreencap
@@ -123,25 +145,11 @@ public class CTscreencap extends TimerTask {
 		//
 		// Specify a shutdown hook to catch Ctrl+c
 		//
+		final CTscreencap temporaryCTS = this;
         Runtime.getRuntime().addShutdownHook(new Thread() {
         	@Override
             public void run() {
-        		// Flag that it is time to shut down
-            	bShutdown = true;
-        		// Shut down CTwriter
-        		if (ctw == null) {
-        			return;
-        		}
-        		ctw.close();
-        		ctw = null;
-        		// shut down audio
-        		if(audioTask != null) audioTask.shutDown();
-        		// Sleep for a bit to allow any currently running tasks to finish
-        		try {
-            		Thread.sleep(1000);
-            	} catch (Exception e) {
-            		// Nothing to do
-            	}
+        		temporaryCTS.exit(true);
             }
         });
 		
@@ -156,10 +164,12 @@ public class CTscreencap extends TimerTask {
 		options.addOption("nm", "no_mouse_cursor", false, "don't include mouse cursor in output screen capture images");
 		options.addOption("nz", "no_zipfiles", false, "don't use ZIP");
 		options.addOption("x", "debug", false, "use debug mode");
-		options.addOption("cd", "change_detect", false, "detect and record only changed images (default="+bChangeDetect+")");		// MJM
-		options.addOption("a", "audio_cap", false, "record audio (default="+bAudioCapture+")");		// MJM
+		options.addOption("cd", "change_detect", false, "detect and record only changed images (default="+bChangeDetect+")"); // MJM
+		options.addOption("a", "audio_cap", false, "record audio (default="+bAudioCapture+")"); // MJM
+		options.addOption("fs", "full_screen", false, "automatically capture full screen (default="+bFullScreen+")");
 
-		// The following example is for: -outputfolder <folder>   (location of output files)
+		// Command line options that include a flag
+		// For example, the following will be for "-outputfolder <folder>   (Location of output files...)"
 		Option outputFolderOption = Option.builder("outputfolder")
                 .argName("folder")
                 .hasArg()
@@ -255,6 +265,8 @@ public class CTscreencap extends TimerTask {
 	    bChangeDetect = line.hasOption("change_detect");
 	    // audio capture mode? MJM
 	    bAudioCapture = line.hasOption("audio_cap");
+	    // Capture the full screen?
+	    bFullScreen = line.hasOption("full_screen");
 	    // Image quality
 	    String imageQualityStr = line.getOptionValue("q",""+imageQuality);
 	    try {
@@ -268,12 +280,17 @@ public class CTscreencap extends TimerTask {
 	    }
 	    
 	    //
+	    // THIS IS OLDER CODE WHERE THE USER SPECIFIED THE REGION TO CAPTURE AHEAD OF TIME;
+	    // WE NOW DO THIS DYNAMICALLY: THE USER PUTS A FRAME AROUND THE REGION TO CAPTURE
+	    // AND CAN CHANGE IT AS THE PROGRAM RUNS
+	    //
 	    // Determine if the GraphicsDevice supports translucency.
 	    // This code is from https://docs.oracle.com/javase/tutorial/uiswing/misc/trans_shaped_windows.html
 	    //
 	    // If translucent windows aren't supported, capture the entire screen.
 	    // Otherwise, have the user draw a rectangle around the area they wish to capture.
 	    //
+	    /*
         GraphicsEnvironment graphEnv = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice graphDev = graphEnv.getDefaultScreenDevice();
         if (!graphDev.isWindowTranslucencySupported(GraphicsDevice.WindowTranslucency.TRANSLUCENT)) {
@@ -282,7 +299,6 @@ public class CTscreencap extends TimerTask {
         } else {
         	// Have user specify region to capture by drawing a rectangle with the mouse
     	    // Create the GUI on the event-dispatching thread
-    	    final CTscreencap temporaryCTS = this;
             SwingUtilities.invokeLater(new Runnable() {
                 @Override
                 public void run() {
@@ -293,12 +309,8 @@ public class CTscreencap extends TimerTask {
                 }
             });
         }
-        
-        //
         // Wait until user has specified the region to capture before proceeding.
-        // This is a bit hokey to just wait until the variable has been defined;
-        // is there a better way to do this?
-        //
+        // (This is a bit hokey just waiting until regionToCapture has been defined, but it works.)
         while (regionToCapture == null) {
         	try {
         		Thread.sleep(500);
@@ -306,9 +318,36 @@ public class CTscreencap extends TimerTask {
         		// Nothing to do
         	}
         }
+        */
+	    
+	    //
+	    // Capture the entire screen in one of two situations:
+	    // 1. The user has requested to do this via the -f command line option
+	    // 2. If the GraphicsDevice does not support translucency
+	    //       (see https://docs.oracle.com/javase/tutorial/uiswing/misc/trans_shaped_windows.html)
+	    // Otherwise, pop up a frame where the user dynamically specifies what to capture.
+	    //
+	    if (bFullScreen) {
+	    	regionToCapture = new Rectangle(Toolkit.getDefaultToolkit().getScreenSize());
+	    	System.err.println("Capturing the entire screen; click Ctrl+c when finished\n");
+	    } else {
+	    	GraphicsEnvironment graphEnv = GraphicsEnvironment.getLocalGraphicsEnvironment();
+	        GraphicsDevice graphDev = graphEnv.getDefaultScreenDevice();
+	        if (!graphDev.isWindowTranslucencySupported(GraphicsDevice.WindowTranslucency.TRANSLUCENT)) {
+	        	bFullScreen = true;
+	            System.err.println("Translucency is not supported; capturing the entire screen; click Ctrl+c when finished\n.");
+	            regionToCapture = new Rectangle(Toolkit.getDefaultToolkit().getScreenSize());
+	        } else {
+	        	// Display a frame containing a translucent panel which will specify the capture region
+	        	// For thread safety: Schedule a job for the event-dispatching thread to create and show the GUI
+	        	SwingUtilities.invokeLater(new Runnable() {
+	        	    public void run() {
+	        	    	temporaryCTS.createAndShowGUI();
+	        	    }
+	        	});
+	        }
+	    }
         
-        System.err.println("Proceeding to screen capture; click Ctrl+c when finished\n");
-		
 		// Setup CTwriter
 		try {
 			CTinfo.setDebug(bDebugMode);
@@ -337,16 +376,6 @@ public class CTscreencap extends TimerTask {
 		//
 		// Setup periodic screen captures
 		//
-		// Method 1:
-		// A periodic timer repeatedly calls the run() method in an instance of ScreencapTask;
-		// in this case, the run() method would handle taking the screencapture and sending it
-		// to CT.  In this method, everything is done synchronously and we end up limiting
-		// the frames/sec that can be achieved.
-		//    ScreencapTask capTask = new ScreencapTask(this);
-		//    timerObj = new Timer();
-        //    timerObj.schedule(capTask, 0, capturePeriodMillis);
-		//
-		// Method 2:
 		// A periodic timer repeatedly calls the run() method in this instance of CTscreencap;
 		// this run() method creates a new instance of ScreencapTask and spawns a new Thread
 		// to run it.  ScreencapTask.run() generates a screencapture and stores it in the
@@ -356,10 +385,18 @@ public class CTscreencap extends TimerTask {
 		timerObj = new Timer();
         timerObj.schedule(this, 0, capturePeriodMillis);
         
-        if(bAudioCapture) audioTask = new AudiocapTask(outputFolder);		// start audio capture (MJM)
+        //
+        // Start audio capture (if requested by the user)
+        //
+        if (bAudioCapture) {
+        	// start audio capture (MJM)
+        	// String audioFolder = outputFolder + "CTaudio";
+        	String audioFolder = outputFolder + sourceName + "_audio";
+        	audioTask = new AudiocapTask(audioFolder);
+        }
         
         //
-        // Grab screen capture byte arrays off the blocking queue and send them to CT
+        // While loop to grab screen capture byte arrays off the blocking queue and send them to CT
         //
         int numScreenCaps = 0;
         while (true) {
@@ -399,9 +436,181 @@ public class CTscreencap extends TimerTask {
 		if (bShutdown) {
 			return;
 		}
+		if (!bFullScreen) {
+			// User will specify the region to capture via the JFame
+			// If the JFrame is not yet up, just return
+			if ( (guiFrame == null) || (!guiFrame.isShowing()) ) {
+				return;
+			}
+			// Update capture region
+			Point loc = capturePanel.getLocationOnScreen();
+			Dimension dim = capturePanel.getSize();
+			Rectangle tempRegionToCapture = new Rectangle(loc,dim);
+			regionToCapture = tempRegionToCapture;
+		}
+		// Create a new ScreencapTask and run it in a new thread
 		ScreencapTask screencapTask = new ScreencapTask(this);
         Thread threadObj = new Thread(screencapTask);
         threadObj.start();
+	}
+	
+	//
+	// Pop up the GUI
+	// this method should be run in the event-dispatching thread
+	//
+	private void createAndShowGUI() {
+		
+		// Make sure we have nice window decorations.
+		JFrame.setDefaultLookAndFeelDecorated(true);
+		
+		// Create the GUI components
+		GridBagLayout framegbl = new GridBagLayout();
+		guiFrame = new JFrame("CTscreencap");
+		guiFrame.setBackground(new Color(0,0,0,0));
+		GridBagLayout gbl = new GridBagLayout();
+		JPanel guiPanel = new JPanel(gbl);
+		guiPanel.setBackground(new Color(0,0,0,0));
+		guiFrame.setFont(new Font("Dialog", Font.PLAIN, 12));
+		guiPanel.setFont(new Font("Dialog", Font.PLAIN, 12));
+		GridBagLayout controlsgbl = new GridBagLayout();
+		controlsPanel = new JPanel(controlsgbl);
+		controlsPanel.setBackground(new Color(211,211,211,255));
+		capturePanel = new JPanel();
+		capturePanel.setBackground(new Color(0,0,0,16));
+        guiFrame.setAlwaysOnTop(true);
+        
+		int row = 0;
+		
+		GridBagConstraints gbc = new GridBagConstraints();
+		gbc.anchor = GridBagConstraints.WEST;
+		gbc.fill = GridBagConstraints.NONE;
+		gbc.weightx = 0;
+		gbc.weighty = 0;
+		
+		// First row: the controls panel
+		gbc.insets = new Insets(0, 0, 0, 0);
+		gbc.fill = GridBagConstraints.HORIZONTAL;
+		gbc.weightx = 100;
+		gbc.weighty = 0;
+		Utility.add(guiPanel, controlsPanel, gbl, gbc, 0, row, 1, 1);
+		gbc.fill = GridBagConstraints.NONE;
+		gbc.weightx = 0;
+		gbc.weighty = 0;
+		++row;
+		
+		// Add controls to the controls panel
+		JLabel label1 = new JLabel("Image quality",SwingConstants.LEFT);
+		JLabel label2 = new JLabel("Frame rate",SwingConstants.LEFT);
+		JButton exitButton = new JButton("Exit");
+		exitButton.addActionListener(this);
+		gbc.anchor = GridBagConstraints.WEST;
+		gbc.fill = GridBagConstraints.HORIZONTAL;
+		gbc.weightx = 100;
+		gbc.weighty = 0;
+		gbc.insets = new Insets(10, 10, 0, 10);
+		Utility.add(controlsPanel, label1, controlsgbl, gbc, 0, 0, 1, 1);
+		gbc.insets = new Insets(10, 10, 10, 10);
+		Utility.add(controlsPanel, label2, controlsgbl, gbc, 0, 1, 1, 1);
+		gbc.insets = new Insets(10, 0, 10, 10);
+		gbc.anchor = GridBagConstraints.EAST;
+		gbc.fill = GridBagConstraints.NONE;
+		gbc.weightx = 0;
+		gbc.weighty = 0;
+		Utility.add(controlsPanel, exitButton, controlsgbl, gbc, 1, 0, 1, 2);
+		gbc.anchor = GridBagConstraints.WEST;
+		gbc.fill = GridBagConstraints.NONE;
+		
+		// Second row: the translucent panel
+		gbc.insets = new Insets(0, 0, 0, 0);
+		gbc.fill = GridBagConstraints.BOTH;
+		gbc.weightx = 100;
+		gbc.weighty = 100;
+		Utility.add(guiPanel, capturePanel, gbl, gbc, 0, row, 1, 1);
+		gbc.fill = GridBagConstraints.NONE;
+		gbc.weightx = 0;
+		gbc.weighty = 0;
+		++row;
+		
+		// Add guiPanel to guiFrame
+		gbc.anchor = GridBagConstraints.CENTER;
+		gbc.fill = GridBagConstraints.BOTH;
+		gbc.weightx = 100;
+		gbc.weighty = 100;
+		gbc.insets = new Insets(0, 0, 0, 0);
+		Utility.add(guiFrame, guiPanel, framegbl, gbc, 0, 0, 1, 1);
+		
+		// Add menu
+		JMenuBar menuBar = createMenu();
+		guiFrame.setJMenuBar(menuBar);
+		
+		// Display the window.
+		guiFrame.pack();
+		
+		guiFrame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+		
+		guiFrame.addWindowListener(new WindowAdapter() {
+			public void windowClosing(WindowEvent e) {
+				exit(false);
+			}
+		});
+		
+		guiFrame.setVisible(true);
+		
+	}
+	
+	//
+	// Create menu for the GUI
+	//
+	private JMenuBar createMenu() {
+		JMenuBar menuBar = new JMenuBar();
+		JMenu menu = new JMenu("File");
+		menuBar.add(menu);
+		JMenuItem menuItem = new JMenuItem("Settings...");
+		menu.add(menuItem);
+		menuItem.addActionListener(this);
+		menuItem = new JMenuItem("Exit");
+		menu.add(menuItem);
+		menuItem.addActionListener(this);
+		return menuBar;
+	}
+	
+	//
+	// Callback for UI controls and menu items
+	//
+	public void actionPerformed(ActionEvent eventI) {
+		Object source = eventI.getSource();
+
+		if (source == null) {
+			return;
+		} else if (eventI.getActionCommand().equals("Exit")) {
+			exit(false);
+		}
+	}
+	
+	//
+	// Exit the application
+	//
+	private void exit(boolean bCalledFromShutdownHookI) {
+		// Flag that it is time to shut down
+    	bShutdown = true;
+		// Shut down CTwriter
+		if (ctw == null) {
+			return;
+		}
+		ctw.close();
+		ctw = null;
+		// shut down audio
+		if(audioTask != null) audioTask.shutDown();
+		// Sleep for a bit to allow any currently running tasks to finish
+		try {
+    		Thread.sleep(1000);
+    	} catch (Exception e) {
+    		// Nothing to do
+    	}
+		System.err.println("\nExit CTscreencap\n");
+		if (!bCalledFromShutdownHookI) {
+			System.exit(0);
+		}
 	}
 	
 	//

--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/DefineCaptureRegion.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/DefineCaptureRegion.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.ctscreencap;
 
@@ -42,6 +39,10 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
+//
+// THIS CLASS IS LEGECY CODE, NO LONGER USED; WE EITHER CAPTURE THE
+// ENTIRE SCREEN OR ELSE THE USER SPECIFIES THE REGION TO CAPTURE
+// BY SURROUNDING IT WITH THE CAPTURE FRAME
 //
 // Define a modal dialog which will contain a panel which covers the entire
 // screen and make it translucent (so user can see what is behind this

--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/ScreencapTask.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/ScreencapTask.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.ctscreencap;
 
@@ -35,15 +32,19 @@ import javax.imageio.ImageWriter;
 import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.ImageOutputStream;
 
-//
-// Generate a screen capture.
-//
-// The run() method in this class generates a screen capture and puts it
-// in the blocking queue managed by CTscreencap.
-//
-// Initial code based on the example found at:
-// http://www.codejava.net/java-se/graphics/how-to-capture-screenshot-programmatically-in-java
-//
+/**
+ * Generate a screen capture.
+ *
+ * The run() method in this class generates a screen capture and puts it
+ * in the blocking queue managed by CTscreencap.
+ *
+ * Initial code based on the example found at:
+ * http://www.codejava.net/java-se/graphics/how-to-capture-screenshot-programmatically-in-java
+ *
+ * @author John P. Wilson
+ * @version 01/26/2017
+ *
+ */
 
 public class ScreencapTask extends TimerTask implements Runnable {
 	

--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/Utility.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/Utility.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.ctscreencap;
 


### PR DESCRIPTION
(a) frame pops up allowing user to specify what region to capture (UI controls yet to be added); (b) by specifying -fs command line option, CTscreencap will automatically capture the entire screen (ie, headless mode); (c) added new Apache headers; (d) if CTscreencap is producing audio, the output folder name is the same as the video output folder with _audio suffix