### PR TITLE
Extensive changes in CTtext

### DIFF
--- a/JavaCode/CTtext/src/main/java/erigo/cttext/CTsettings.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/CTsettings.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.cttext;
 
@@ -81,8 +78,8 @@ public class CTsettings extends JDialog implements ActionListener,ItemListener {
 														// this is a special case for "max responsiveness": no ZIP data, set auto flush = maxResponsivenessFlushLevel
 	private static final double maxResponsivenessFlushInterval = 10.0;
 														// If flushInterval == -1 (i.e., "max responsiveness") then auto flush interval =  maxResponsivenessFlushLevel
-														// data is not ZIP'ed in this case, so it actually shows up on disk immediately; the flush interval just
-														// determines when Blocks are closed and the next Block folder starts.
+														// (which is a time in milliseconds); data is not ZIP'ed in this case, so it actually shows up on disk immediately;
+														// note that flush interval determines when Blocks are closed and the next Block folder starts.
 	private static final int blocksPerSegment = 10;		// Fixed setting; Number of Block folders per Segment; 0 = no segments
 	private boolean bUseRelativeTime = true;			// Fixed to true (we no longer use absolute timestamps)
 	private boolean bZipData = true;					// Block folders will be zipped?  This will be true for all cases except:

--- a/JavaCode/CTtext/src/main/java/erigo/cttext/CTsettings.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/CTsettings.java
@@ -66,26 +66,24 @@ public class CTsettings extends JDialog implements ActionListener,ItemListener {
 	// Settings
 	private String outputFolder = "CTdata" + File.separator + "CTtext";
 	private String chanName = "cttext.txt";
-	private boolean bUseFTP = false;					// Use FTP to write data out?
-	private String ftpHost = "";						// FTP hostname
-	private String ftpUser = "";						// FTP username
-	private String ftpPassword = "";					// FTP password
-	private boolean bManualFlush = false;				// If this is true, user will manually click a "Flush" button at which time the code will putData and flush
-														// If this is false, putData is called for every Document edit and the flush interval is specified by:
-														//     (1) if flushInterval == -1 (i.e., "max responsiveness") then auto flush interval =  maxResponsivenessFlushLevel
-														//     (2) if flushInterval > 0, use this value as the auto flush interval
-	private double flushInterval = 10.0;				// Interval (sec) at which to automatically flush data; if value is -1,
-														// this is a special case for "max responsiveness": no ZIP data, set auto flush = maxResponsivenessFlushLevel
+	private boolean bUseFTP = false;				// Use FTP to write data out?
+	private String ftpHost = "";					// FTP hostname
+	private String ftpUser = "";					// FTP username
+	private String ftpPassword = "";				// FTP password
+	private boolean bManualFlush = false;			// If true, CTwriter setTime, putData and flush calls are made every time WriteTask processes a text update
+													// If false, setTime and putData (but not flush) are called every time WriteTask processes a text update;
+													//     CTwriter auto flush is used in this case, the interval of which is specified by flushInterval
+	private double flushInterval = 10.0;			// Interval (sec) at which to automatically flush data
+													//     -1 is a special case for "max responsiveness": no ZIP data, auto flush = maxResponsivenessFlushLevel
+													//     note that flush interval determines when Blocks are closed and the next Block folder starts
 	private static final double maxResponsivenessFlushInterval = 10.0;
-														// If flushInterval == -1 (i.e., "max responsiveness") then auto flush interval =  maxResponsivenessFlushLevel
-														// (which is a time in milliseconds); data is not ZIP'ed in this case, so it actually shows up on disk immediately;
-														// note that flush interval determines when Blocks are closed and the next Block folder starts.
-	private static final int blocksPerSegment = 10;		// Fixed setting; Number of Block folders per Segment; 0 = no segments
-	private boolean bUseRelativeTime = true;			// Fixed to true (we no longer use absolute timestamps)
-	private boolean bZipData = true;					// Block folders will be zipped?  This will be true for all cases except:
-														//     (1) If flush interval is -1 ("Max responsiveness")
-														//     (2) When bManualFlush is true (put and flush are done right away, so no need to ZIP since Block only contains 1 data point)
-	private boolean bChatMode = false;					// Not currently used
+													// If flushInterval == -1 ("max responsiveness") auto flush interval is set to maxResponsivenessFlushLevel (msec)
+													//     data is not ZIP'ed in this case, so it essentially shows up on disk immediately
+	private static final int blocksPerSegment = 10;	// Number of Block folders per Segment; 0 = no segments; this value is not user-editable
+	private boolean bUseRelativeTime = true;		// Fixed to true (we no longer use absolute timestamps)
+	private boolean bZipData = true;				// Are Block folders ZIP'ed?  Will be true except for:
+													//     (1) If flush interval is -1 ("Max responsiveness")
+													//     (2) When bManualFlush is true (no need to ZIP since each Block only contains 1 data point)
 	
 	// Backup copy of the settings used when user is editing the settings
 	private String orig_outputFolder;
@@ -98,7 +96,6 @@ public class CTsettings extends JDialog implements ActionListener,ItemListener {
 	private double orig_flushInterval;
 	private boolean orig_bUseRelativeTime;
 	private boolean orig_bZipData;
-	private boolean orig_bChatMode;
 	
 	// Dialog components
 	private JTextField outputDirTF = null;
@@ -463,20 +460,6 @@ public class CTsettings extends JDialog implements ActionListener,ItemListener {
 	}
 	
 	/*
-	 * Accessor method for bChatMode
-	 */
-	public boolean getBChatMode() {
-		return bChatMode;
-	}
-	
-	/*
-	 * Mutator method for bChatMode
-	 */
-	public void setBChatMode(boolean bChatModeI) {
-		bChatMode = bChatModeI;
-	}
-	
-	/*
 	 * Accessor method for bClickedOK
 	 */
 	public boolean getBClickedOK() {
@@ -551,7 +534,6 @@ public class CTsettings extends JDialog implements ActionListener,ItemListener {
 		orig_flushInterval = flushInterval;
 		orig_bUseRelativeTime = bUseRelativeTime;
 		orig_bZipData = bZipData;
-		orig_bChatMode = bChatMode;
 		
 		// Initialize data in the dialog
 		outputDirTF.setText(outputFolder);
@@ -703,7 +685,6 @@ public class CTsettings extends JDialog implements ActionListener,ItemListener {
 		flushInterval = orig_flushInterval;
 		bUseRelativeTime = orig_bUseRelativeTime;
 		bZipData = orig_bZipData;
-		bChatMode = orig_bChatMode;
 		
 		setBClickedOK(false);
 		
@@ -736,11 +717,7 @@ public class CTsettings extends JDialog implements ActionListener,ItemListener {
 				sb.append("\tputData is called with every document change; ZIP is on; automatically flush every " + flushInterval + " seconds\n");
 			}
 		}
-		if (blocksPerSegment == 0) {
-			sb.append("\tBlocks per Segment = " + blocksPerSegment + ", i.e. no segment folders\n");
-		} else {
-			sb.append("\tBlocks per Segment = " + blocksPerSegment + "\n");
-		}
+		sb.append("\tBlocks per Segment = " + blocksPerSegment + "; if this value is zero then we will not have any segment folders\n");
 		sb.append("\tUse relative time = " + bUseRelativeTime + "\n");
 		
 		return sb.toString();

--- a/JavaCode/CTtext/src/main/java/erigo/cttext/CTtext.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/CTtext.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.cttext;
 
@@ -24,9 +21,13 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.HeadlessException;
 import java.awt.Insets;
 
 import javax.swing.JButton;
@@ -34,11 +35,35 @@ import javax.swing.JFrame;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
+import cycronix.ctlib.*;
+
+/**
+ * 
+ * Save user-entered text from a JText UI control to CloudTurbine.
+ * 
+ * Classes involved in this application:
+ * -------------------------------------
+ * 1. CTtext: main class; manages the GUI and program flow; manages the CTwriter object
+ * 2. DocumentChangeListener: responds to text edit events; save a "snapshot" of
+ *       the text as a String to the blocking queue.
+ * 3. WriteTask: grab Strings off the queue and write them to CT; this is executed
+ *       in a separate Thread
+ * 4. CTsettings: saves settings the user has specified about how to save data to CT;
+ *       also supports a dialog to allow the user to edit these settings
+ * 5. Utility: contains a utility method to add a control to the UI
+ * 
+ * Two flushing modes are supported: user can manually 
+ *
+ * @author John P. Wilson
+ * @version 02/10/2017
+ *
+ */
 public class CTtext implements ActionListener {
 
 	// GUI components
@@ -47,13 +72,31 @@ public class CTtext implements ActionListener {
 	private JScrollPane scrollPane = null;
 	private JButton manualFlushButton = null;
 	
+	// Queue of Strings waiting to be written to CT
+	public BlockingQueue<String> queue = null;
+	
+	// Objects which do "work"
+	public CTwriter ctw = null;						// CTwriter instance, used by WriteTask
+	private DocumentChangeListener ctDoc = null;	// Responds to user edits by saving entire document as a String and putting it in the queue
+	private WriteTask writeTask = null;				// This task takes Strings off the queue and writes them to CT
+	private Thread writeTaskThread = null;			// The thread running in WriteTask
+	
+	// Lock object used by the synchronized blocks in CTtext and WriteTask
+	public Object ctwLockObj = new Object();
+	
 	// CloudTurbine settings
 	public CTsettings ctSettings = null;
-	public boolean bCTrunning = false;
+	public boolean bDebugMode = false;	// run CT in debug mode?
+	public boolean bCTrunning = false;	// is CTwriter open?
+	public boolean bForceFlush = false;	// used with manual flush; force flush on CTwriter
 	
-	// Class to handle interaction between the document and CloudTurbine
-	private DocumentChangeListener ctDoc = null;
-    
+    /**
+     * main
+     * 
+     * Create an instance of CTtext and pop up its GUI.
+     * 
+     * @param argsI Input arguments (none currently supported).
+     */
 	public static void main(String[] argsI) {
         
 		final CTtext cttext = new CTtext();
@@ -68,15 +111,23 @@ public class CTtext implements ActionListener {
         
 	}
     
+	/**
+	 * CTtext constructor
+	 */
 	public CTtext() {
 		ctDoc = new DocumentChangeListener(this);
 	}
     
+	/**
+	 * createAndShowGUI
+	 * 
+	 * Create the CTtext GUI; this method should be run on the event dispatch thread.
+	 */
 	private void createAndShowGUI() {
-
+		
 		// Make sure we have nice window decorations.
 		JFrame.setDefaultLookAndFeelDecorated(true);
-
+		
 		// Create the GUI components
 		GridBagLayout framegbl = new GridBagLayout();
 		cttextGuiFrame = new JFrame("CTtext");
@@ -90,12 +141,19 @@ public class CTtext implements ActionListener {
 		textArea.setEditable(false);
 		textArea.setBackground(Color.LIGHT_GRAY);
 		
-		// DISABLE THE KEY BINDING FOR NOW
-		// DON'T NEED TO RESPOND TO LINE FEEDS AS CTwriter WILL EITHER FLUSH CONTENT WITH EVERY EDIT OR ELSE USE ASYNC AUTO FLUSH
+		//
+		// DISABLE THE KEY BINDING SINCE WE DON'T NEED TO RESPOND TO LINE FEEDS;
+		// CTwriter WILL EITHER FLUSH CONTENT WITH EVERY EDIT OR ELSE USE ASYNC AUTO FLUSH
+		//
 		// Add a KeyBinding to the JTextArea so we know when the user hits the ENTER key
+		// Information about Key Bindings and Key Listeners:
+		// o Key Binding (good tutorial): http://www.dreamincode.net/forums/topic/245148-java-key-binding-tutorial-and-demo-program/
+		// o Key Binding versus Key Listener: http://stackoverflow.com/questions/15290035/key-bindings-vs-key-listeners-in-java
+		// o DocumentListener and Key Binding: http://docs.oracle.com/javase/tutorial/uiswing/components/generaltext.html
 		// textArea.getInputMap().put(KeyStroke.getKeyStroke( "ENTER" ),"doEnterAction" );
-		// Specify that the action "doEnterAction" will be implemented by ctDoc
-		// textArea.getActionMap().put("doEnterAction",ctDoc);
+		// Specify that the action "doEnterAction" will be implemented by this object
+		// (the actionPerformed() method will get a callback when the user hits ENTER)
+		// textArea.getActionMap().put("doEnterAction",this);
 		
 		scrollPane = new JScrollPane(textArea);
 		
@@ -168,6 +226,11 @@ public class CTtext implements ActionListener {
 		
 	}
 	
+	/**
+	 * Create the menu to be added to the GUI
+	 * 
+	 * @return the menu to be added to the GUI
+	 */
 	private JMenuBar createMenu() {
 		JMenuBar menuBar = new JMenuBar();
 		JMenu menu = new JMenu("File");
@@ -181,14 +244,27 @@ public class CTtext implements ActionListener {
 		return menuBar;
 	}
 	
+	/**
+	 * 
+	 * @return the parent GUI frame
+	 */
 	public JFrame getParentFrame() {
 		return cttextGuiFrame;
 	}
 	
+	/**
+	 * 
+	 * @return the text area UI control
+	 */
 	public JTextArea getTextArea() {
 		return textArea;
 	}
-
+	
+	/**
+	 * Action callback method.
+	 * 
+	 * @param eventI The event that has occurred.
+	 */
 	public void actionPerformed(ActionEvent eventI) {
 
 		Object source = eventI.getSource();
@@ -197,8 +273,7 @@ public class CTtext implements ActionListener {
 			return;
 		} else if (eventI.getActionCommand().equals("Settings...")) {
 			// Turn off streaming
-			bCTrunning = false;
-			ctDoc.closeStreaming();
+			stopTextToCT();
 			// Disable editing
 			enableEditingUI(false,false);
 			// Let user edit settings
@@ -212,7 +287,9 @@ public class CTtext implements ActionListener {
 				enableEditingUI(true,ctSettings.getBManualFlush());
 			}
 		} else if (eventI.getActionCommand().equals("Flush")) {
-			// Manually save and flush the document (ie, this ends up calling putData() and flush())
+			// This will only occur if manual flush is turned on
+			// Manually save the document;
+			// in WriteTask, ctw.flush() will be called since manual flush is turned on
 			ctDoc.processText(null);
 		} else if (eventI.getActionCommand().equals("Exit")) {
 			exit();
@@ -220,8 +297,11 @@ public class CTtext implements ActionListener {
 		
 	}
 	
-	/*
+	/**
 	 * Setup the user interface to either enable or disable editing
+	 * 
+	 * @param bEnableTextArea Should the text area be enabled?
+	 * @param bEnableManualFlush Should the manual flush button be enabled?
 	 */
 	public void enableEditingUI(boolean bEnableTextArea,boolean bEnableManualFlush) {
 		textArea.setEditable(bEnableTextArea);
@@ -233,10 +313,146 @@ public class CTtext implements ActionListener {
 		}
 	}
 	
+	/**
+	 * startTextToCT
+	 * 
+	 * Open CTwriter and supporting resources to allow text to stream to CloudTurbine.
+	 */
+	public void startTextToCT() {
+		
+		// Firewalls
+		// By the time we get to this function, ctw should be null (ie, no currently active CT connection)
+		if (ctw != null) 		{ System.err.println("ERROR in startTextToCT(): CTwriter object is not null; returning"); return; }
+		if (writeTask != null)	{ System.err.println("ERROR in startTextToCT(): WriteTask object is not null; returning"); return; }
+		if (queue != null)		{ System.err.println("ERROR in startTextToCT(): LinkedBlockingQueue object is not null; returning"); return; }
+		
+		System.err.println("\nStart new periodic screen capture");
+		
+		bCTrunning = true;
+		
+		//
+		// Setup CTwriter
+		//
+		String destFolder = ctSettings.getOutputFolder();
+		System.err.println("Create CTwriter, output to \"" + destFolder + "\"");
+		String errMsg = null;
+		CTinfo.setDebug(bDebugMode);
+		if (!ctSettings.getBUseFTP()) {
+			try {
+				ctw = new CTwriter(destFolder);
+			} catch (IOException ioe) {
+				errMsg = "Error trying to create CloudTurbine writer object:\n" + ioe.getMessage();
+			}
+		} else {
+			CTftp ctftp = null;
+			try {
+				ctftp = new CTftp(destFolder);
+			} catch (IOException ioe) {
+				errMsg = "Error trying to create CloudTurbine FTP writer object:\n" + ioe.getMessage();
+			}
+			try {
+				ctftp.login(ctSettings.getFTPHost(),ctSettings.getFTPUser(),ctSettings.getFTPPassword());
+				// upcast to CTWriter
+				ctw = ctftp;
+			} catch (Exception e) {
+				errMsg = "Error logging into FTP server \"" + ctSettings.getFTPHost() + "\":\n" + e.getMessage();
+			}
+		}
+		if (errMsg != null) {
+			stopTextToCT();
+			enableEditingUI(false,false);
+			System.err.println(errMsg);
+			try {
+				JOptionPane.showMessageDialog(getParentFrame(), errMsg, "CloudTurbine error", JOptionPane.ERROR_MESSAGE);
+			} catch (HeadlessException he) {
+				// Nothing to do
+			}
+			return;
+		}
+		ctw.autoSegment(ctSettings.getBlocksPerSegment());
+		// "Block" mode is for packed data (multiple points per output file);
+		// we don't want this; in our case, each output file will be one "data point"
+		ctw.setBlockMode(false);
+		ctw.setTimeRelative(ctSettings.getBUseRelativeTime());
+		ctw.setZipMode(ctSettings.getBZipData(),1);
+		if (!ctSettings.getBManualFlush()) {
+			if ((int)ctSettings.getFlushInterval() == -1) {
+				// This is "max responsive" mode; there's no ZIP, so data is written out right away;
+				// the length of a Block (ie, flush interval) is specified by the constant maxResponsivenessFlushInterval
+				ctw.autoFlush(ctSettings.getMaxResponsivenessFlushInterval(),true);
+			} else {
+				ctw.autoFlush(ctSettings.getFlushInterval(),true);
+			}
+		}
+		
+		//
+		// Setup the asynchronous event queue to store Strings
+		//
+		queue = new LinkedBlockingQueue<String>();
+		
+		//
+		// Create a new WriteTask which continually grabs Strings off the queue and writes them to CT
+		// Run this in a new thread
+		//
+		writeTask = new WriteTask(this);
+		writeTaskThread = new Thread(writeTask);
+		writeTaskThread.start();
+		
+	}
+	
+	/**
+     * stopTextToCT
+     * 
+     * Cleanly shut down text streaming to CloudTurbine.
+     */
+    public void stopTextToCT() {
+    	
+    	System.err.println("\n\nStop sending Strings to CloudTurbine");
+    	
+    	bCTrunning = false;
+    	
+    	// shut down WriteTask
+    	if (writeTaskThread != null) {
+    		try {
+    			System.err.println("Wait for WriteTask to stop");
+    			writeTaskThread.join(500);
+    			if (writeTaskThread.isAlive()) {
+    				// WriteTask must be waiting to take another screencap off the queue;
+    				// interrupt it
+    				writeTaskThread.interrupt();
+    				writeTaskThread.join(500);
+    			}
+    			if (!writeTaskThread.isAlive()) {
+    				System.err.println("WriteTask has stopped");
+    			}
+    		} catch (InterruptedException ie) {
+    			System.err.println("Caught exception trying to stop WriteTask:\n" + ie);
+    		}
+    		writeTaskThread = null;
+    		writeTask = null;
+    	}
+    	
+    	// shut down CTwriter
+    	if (ctw != null) {
+    		System.err.println("Close CTwriter");
+    		ctw.close();
+    		ctw = null;
+    	}
+    	
+    	if (queue != null) {
+    		queue.clear();
+    		queue = null;
+    	}
+    	
+    }
+	
+    /**
+     * Exit the application.
+     */
 	private void exit() {
         
 		// Turn off streaming
-		ctDoc.closeStreaming();
+		stopTextToCT();
 		
 		cttextGuiFrame.setVisible(false);
         

--- a/JavaCode/CTtext/src/main/java/erigo/cttext/CTtext.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/CTtext.java
@@ -128,7 +128,6 @@ public class CTtext implements ActionListener {
 	public CTsettings ctSettings = null;
 	public boolean bDebugMode = false;	// run CT in debug mode?
 	public boolean bCTrunning = false;	// is CTwriter open?
-	public boolean bForceFlush = false;	// used with manual flush; force flush on CTwriter
 	
     /**
      * main

--- a/JavaCode/CTtext/src/main/java/erigo/cttext/DocumentChangeListener.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/DocumentChangeListener.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.cttext;
 
@@ -23,67 +20,30 @@ package erigo.cttext;
  * 
  * Handle events when the user changes text in the JTextArea.
  * 
- * CTwriter will flush data every time the user hits ENTER in the text area.
- * We use a Key Binding and the actionPerformed() method in this class to
- * be notified when the user has hit ENTER.  When this occurs, the
- * Key Binding action (ie, method actionPerformed()) will set a flag
- * (ie, bTimeToFlush) to signal DocumentListener that a flush needs to take place.
- * 
- * Example/forum posts about DocumentListener, Key Bindings and Key Listeners:
- * 1. DocumentListener and Key Binding: http://docs.oracle.com/javase/tutorial/uiswing/components/generaltext.html
- * 2. Key Binding (good tutorial): http://www.dreamincode.net/forums/topic/245148-java-key-binding-tutorial-and-demo-program/
- * 3. Key Binding versus Key Listener: http://stackoverflow.com/questions/15290035/key-bindings-vs-key-listeners-in-java
- * 
  */
 
-import cycronix.ctlib.*;
-
-import java.io.IOException;
-import java.awt.HeadlessException;
-import java.awt.event.ActionEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.JOptionPane;
-import javax.swing.JTextArea;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 
-public class DocumentChangeListener extends AbstractAction implements DocumentListener {
-    
-	private static final long serialVersionUID = 2349959704230725018L;
-	private CTtext hCTtext = null;
-	private CTwriter ctw = null;
-	private boolean bTimeToFlush = false;
+public class DocumentChangeListener implements DocumentListener {
 	
-	/*
+	private CTtext hCTtext = null;
+	
+	/**
 	 * Constructor
 	 * 
 	 * Save CTtext object handle. 
+	 * 
+	 * @param CTtext CTtext instance
 	 */
 	public DocumentChangeListener(CTtext cttextI) {
 		hCTtext = cttextI;
-		// CTinfo.setDebug(true);
 	}
 	
-	// Key binding callback when the user hits ENTER in the JTextArea;
-	// signal the DocumentListener that it is time to flush by setting
-	// bTimeToFlush to true
-	//
-	// NOTE: The key binding is currently disabled in CTtext.createAndShowGUI()  
-	//
-	public void actionPerformed( ActionEvent ae ) {
-		// It is time to do a flush
-		bTimeToFlush = true;
-		
-		// Append the line feed in the JTextArea
-		// This will result in the DocumentListener being called
-		JTextArea textArea = (JTextArea)ae.getSource();
-		textArea.append(System.getProperty("line.separator"));
-	}
-	
-	/* (non-Javadoc)
+	/**
+	 * changedUpdate
+	 * 
 	 * @see javax.swing.event.DocumentListener#changedUpdate(javax.swing.event.DocumentEvent)
 	 */
 	@Override
@@ -93,7 +53,9 @@ public class DocumentChangeListener extends AbstractAction implements DocumentLi
 		}
 	}
 
-	/* (non-Javadoc)
+	/**
+	 * insertUpdate
+	 * 
 	 * @see javax.swing.event.DocumentListener#insertUpdate(javax.swing.event.DocumentEvent)
 	 */
 	@Override
@@ -103,7 +65,9 @@ public class DocumentChangeListener extends AbstractAction implements DocumentLi
 		}
 	}
 
-	/* (non-Javadoc)
+	/**
+	 * removeUpdate
+	 * 
 	 * @see javax.swing.event.DocumentListener#removeUpdate(javax.swing.event.DocumentEvent)
 	 */
 	@Override
@@ -113,18 +77,11 @@ public class DocumentChangeListener extends AbstractAction implements DocumentLi
 		}
 	}
 	
-	/*
-	 * If CloudTurbine streaming is turned on and the document length is greater than 0,
-	 * then send text to CloudTurbine.
+	/**
+	 * processText
 	 * 
-	 * Question: If a user is typing fast enough or the document is large enough, will
-	 *           we be able to keep up with the changes?  If not, we could do the
-	 *           following:
-	 *           a) Have all CTwriter operations running in a separate thread
-	 *           b) Every time a Document event comes in, grab the text and add it
-	 *              as a new Element in a Vector
-	 *           c) As fast as the CTwriter thread is able, it will grab Elements
-	 *              off the Vector and write to CloudTurbine.
+	 * If CloudTurbine streaming is turned on and the document length is greater than 0,
+	 * then queue a message to be sent to CloudTurbine.
 	 * 
 	 * NOTE: Be careful how we use the variable DocumentEvent e_use_carefully, as
 	 *       there are cases where direct calls to processText() are made with
@@ -134,72 +91,9 @@ public class DocumentChangeListener extends AbstractAction implements DocumentLi
 	 */
     public void processText(DocumentEvent e_use_carefully) {
     	
-    	// Flush if bTimeToFlush is true (which is set in actionPerformed())
-    	boolean bLocalTimeToFlush = bTimeToFlush;
-    	bTimeToFlush = false;
-    	
     	// Only process data if CloudTurbine streaming is active
     	if (!hCTtext.bCTrunning) {
-    		if (ctw != null) {
-    			closeStreaming();
-    		}
     		return;
-    	}
-    	
-    	CTsettings ctSettings = hCTtext.ctSettings;
-    	
-    	// Create the CTwriter object if needed
-    	if (ctw == null) {
-    		String destFolder = ctSettings.getOutputFolder();
-    		System.err.println("Create CTwriter, output to \"" + destFolder + "\"");
-    		String errMsg = null;
-    		if (!ctSettings.getBUseFTP()) {
-    			try {
-    				ctw = new CTwriter(destFolder);
-    			} catch (IOException ioe) {
-    				errMsg = "Error trying to create CloudTurbine writer object:\n" + ioe.getMessage();
-    			}
-    		} else {
-    			CTftp ctftp = null;
-    			try {
-    				ctftp = new CTftp(destFolder);
-    			} catch (IOException ioe) {
-    				errMsg = "Error trying to create CloudTurbine FTP writer object:\n" + ioe.getMessage();
-    			}
-    			try {
-    				ctftp.login(ctSettings.getFTPHost(),ctSettings.getFTPUser(),ctSettings.getFTPPassword());
-    				// upcast to CTWriter
-        			ctw = ctftp;
-    			} catch (Exception e) {
-    				errMsg = "Error logging into FTP server \"" + ctSettings.getFTPHost() + "\":\n" + e.getMessage();
-    			}
-    		}
-    		if (errMsg != null) {
-    			closeStreaming();
-    			hCTtext.enableEditingUI(false,false);
-    			System.err.println(errMsg);
-    			try {
-    			    JOptionPane.showMessageDialog(hCTtext.getParentFrame(), errMsg, "CloudTurbine error", JOptionPane.ERROR_MESSAGE);
-    			} catch (HeadlessException he) {
-    				// Nothing to do
-    			}
-    			return;
-    		}
-    		ctw.autoSegment(ctSettings.getBlocksPerSegment());
-    		// "Block" mode is for packed data (multiple points per output file);
-    		// we don't want this; in our case, each output file will be one "data point"
-    		ctw.setBlockMode(false);
-    		ctw.setTimeRelative(ctSettings.getBUseRelativeTime());
-    		ctw.setZipMode(ctSettings.getBZipData(),1);
-    		if (!ctSettings.getBManualFlush()) {
-    			if ((int)ctSettings.getFlushInterval() == -1) {
-    				// This is "max responsive" mode; there's no ZIP, so data is written out right away;
-    				// the length of a Block (ie, flush interval) is specified by the constant maxResponsivenessFlushInterval
-    				ctw.autoFlush(ctSettings.getMaxResponsivenessFlushInterval(),true);
-    			} else {
-    				ctw.autoFlush(ctSettings.getFlushInterval(),true);
-    			}
-    		}
     	}
     	
     	// Write out document (as long as it isn't empty)
@@ -215,37 +109,19 @@ public class DocumentChangeListener extends AbstractAction implements DocumentLi
     		try {
     			currentText = document.getText(0, document.getLength());
     			// System.err.println("\n<<\n" + currentText + "\n>>\n");
-    		} catch (BadLocationException e1) {
-    			System.err.println("Error fetching text:\n" + e1);
-    			return;
-    		}
-    		try {
-    			ctw.setTime(System.currentTimeMillis());
-    			ctw.putData(ctSettings.getChanName(), currentText);
-    			// Flush if either of the following is true:
-    			// 1. bLocalTimeToFlush is true; we don't currently use this; this variable will be true
-    			//    if we are responding to ENTER key presses by the user in the text area; this method
-    			//    isn't currently being used
-    			// 2. if we *aren't* doing auto flushes (which are handled asynchronously) then go ahead and flush
-    			if ( (bLocalTimeToFlush) || (ctSettings.getBManualFlush()) ) {
-    				ctw.flush();
+    			System.out.print(".");
+    			// Add currentText to the queue
+        		hCTtext.queue.put(currentText);
+    		} catch (Exception excep) {
+    			if (hCTtext.bCTrunning) {
+    				// Only print out error messages if we know we aren't in shutdown mode
+    			    System.err.println("\nError processing text:\n" + excep);
+    			    excep.printStackTrace();
     			}
-    		} catch (Exception e1) {
-    			System.err.println("\nError writing data to CloudTurbine:\n" + e1.getMessage());
     			return;
     		}
     	}
     	
-    }
-    
-    /*
-     * Cleanly shut down streaming.
-     */
-    public void closeStreaming() {
-    	if (ctw != null) {
-    	    ctw.close();
-    	}
-		ctw = null;
     }
     
 }

--- a/JavaCode/CTtext/src/main/java/erigo/cttext/DocumentChangeListener.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/DocumentChangeListener.java
@@ -35,7 +35,7 @@ public class DocumentChangeListener implements DocumentListener {
 	 * 
 	 * Save CTtext object handle. 
 	 * 
-	 * @param CTtext CTtext instance
+	 * @param cttextI CTtext instance
 	 */
 	public DocumentChangeListener(CTtext cttextI) {
 		hCTtext = cttextI;
@@ -45,6 +45,8 @@ public class DocumentChangeListener implements DocumentListener {
 	 * changedUpdate
 	 * 
 	 * @see javax.swing.event.DocumentListener#changedUpdate(javax.swing.event.DocumentEvent)
+	 * 
+	 * @param e The DocumentEvent that has occurred.
 	 */
 	@Override
 	public void changedUpdate(DocumentEvent e) {
@@ -57,6 +59,8 @@ public class DocumentChangeListener implements DocumentListener {
 	 * insertUpdate
 	 * 
 	 * @see javax.swing.event.DocumentListener#insertUpdate(javax.swing.event.DocumentEvent)
+	 * 
+	 * @param e The DocumentEvent that has occurred.
 	 */
 	@Override
 	public void insertUpdate(DocumentEvent e) {
@@ -69,6 +73,8 @@ public class DocumentChangeListener implements DocumentListener {
 	 * removeUpdate
 	 * 
 	 * @see javax.swing.event.DocumentListener#removeUpdate(javax.swing.event.DocumentEvent)
+	 * 
+	 * @param e The DocumentEvent that has occurred.
 	 */
 	@Override
 	public void removeUpdate(DocumentEvent e) {
@@ -88,6 +94,7 @@ public class DocumentChangeListener implements DocumentListener {
 	 *       a null argument.  For instance, when the user manually "Saves"
 	 *       the document, we call this method directly from CTtext.actionPerformed()
 	 * 
+	 * @param e_use_carefully  The DocumentEvent that has occurred; when this method is called manually, this parameter will be null.
 	 */
     public void processText(DocumentEvent e_use_carefully) {
     	

--- a/JavaCode/CTtext/src/main/java/erigo/cttext/Utility.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/Utility.java
@@ -1,21 +1,18 @@
-/*******************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *******************************************************************************/
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package erigo.cttext;
 

--- a/JavaCode/CTtext/src/main/java/erigo/cttext/WriteTask.java
+++ b/JavaCode/CTtext/src/main/java/erigo/cttext/WriteTask.java
@@ -1,0 +1,98 @@
+/*
+Copyright 2017 Erigo Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package erigo.cttext;
+
+/**
+ * WriteTask is a Runnable object which takes Strings off the
+ * blocking queue (CTtext.queue) and writes them to CT.
+ *
+ * @author John P. Wilson
+ * @version 02/10/2017
+ *
+ */
+
+public class WriteTask implements Runnable {
+	
+	private CTtext hCTtext = null;
+	
+	/**
+	 * 
+	 * Constructor
+	 * 
+	 * @param  ctTextI  The CTtext object.
+	 */
+	public WriteTask(CTtext ctTextI) {
+		hCTtext = ctTextI;
+	}
+	
+	/**
+	 * 
+	 * run()
+	 * 
+	 * This method performs the work of writing screen captures to CloudTurbine.
+	 * A while loop takes screen capture byte arrays off the blocking queue and
+	 * send them to CT.
+	 */
+	public void run() {
+		
+		int numScreenCaps = 0;
+		
+		while (true) {
+			if (!hCTtext.bCTrunning) {
+				break;
+			}
+			String nextStr = null;
+			try {
+				nextStr = hCTtext.queue.take();
+			} catch (InterruptedException e) {
+				if (!hCTtext.bCTrunning) {
+					break;
+				} else {
+					System.err.println("Caught exception working with the LinkedBlockingQueue:\n" + e);
+				}
+			}
+			if ((nextStr != null) && (!nextStr.isEmpty())) {
+				try {
+					// synchronize calls to the common CTwriter object using a common CTtext.ctwLockObj object
+					synchronized(hCTtext.ctwLockObj) {
+						hCTtext.ctw.setTime(System.currentTimeMillis());
+						hCTtext.ctw.putData(hCTtext.ctSettings.getChanName(),nextStr);
+						// Flush if we're doing manual flushes (i.e., we *aren't* doing auto flushes)
+		    			if (hCTtext.ctSettings.getBManualFlush()) {
+		    				hCTtext.ctw.flush();
+		    			}
+					}
+				} catch (Exception e) {
+					if (!hCTtext.bCTrunning) {
+						break;
+					} else {
+						System.err.println("Caught CTwriter exception:\n" + e);
+					}
+				}
+				System.out.print("x");
+				numScreenCaps += 1;
+				if ((numScreenCaps % 40) == 0) {
+					System.err.print("\n");
+				}
+			}
+		}
+		
+		System.err.println("WriteTask is exiting");
+		
+	}
+	
+}


### PR DESCRIPTION
Extensive changes in CTtext, most of them "under the hood".  The GUI and CTwriter now execute in asynchronous threads; this is important, for instance, when sending data via FTP so as to not make GUI behavior choppy.  CTtext's framework is now similar to that of CTscreencap.  In both programs, data to send to CT is put on a queue; an instance of WriteTask (which executes in its own thread) takes objects off the queue and sends them to CT.

Inline documentation in the CTtext.java header describes program flow.

The only significant GUI change is that there are separate menu items to start data flow to CT and to stop CT.  This seems better than the previous method, where the user had to bring up the Settings dialog and clicks OK before CT data flow started.