### PR TITLE
CTreader change to public oldTime() and newTime() methods

### DIFF
--- a/JavaCode/CTadmin/src/main/java/ctadmin/CTadmin.java
+++ b/JavaCode/CTadmin/src/main/java/ctadmin/CTadmin.java
@@ -192,8 +192,9 @@ public class CTadmin extends Application {
 				long dataSize = CTinfo.diskSize;	// shortcut, fetch side-effect from prior diskUsage() call (cluge for speed)
 
 				SimpleDateFormat format = new SimpleDateFormat("MMM dd, yyyy, HH:mm:ss");
-				double oldTime = myCTreader.oldTime(fullPath);
-				double newTime = myCTreader.newTime(fullPath);
+				// JPW, in next 2 calls, changed from fullPath to sourcePath (ie, don't use full path)
+				double oldTime = myCTreader.oldTime(sourcePath);
+				double newTime = myCTreader.newTime(sourcePath);
 				double duration = newTime - oldTime;
 				String newTimeStr = format.format((long)(newTime*1000.));
 

--- a/JavaCode/CTexample/src/main/java/CTstitch.java
+++ b/JavaCode/CTexample/src/main/java/CTstitch.java
@@ -61,7 +61,8 @@ public class CTstitch {
 				String sessionPath = sourceFolder + File.separator + sessionRoot;
 				
 				if(init) {
-					priorTime = 1 + (long)(ctr.newTime(sessionPath)*1000.);		// sec -> msec
+					// JPW, change from using sessionPath to sessionRoot (ie, use relative path, not including root folder)
+					priorTime = 1 + (long)(ctr.newTime(sessionRoot)*1000.);		// sec -> msec
 				}
 				else {		// prior source
 					String newSession = sourceFolder + File.separator + priorTime;
@@ -73,7 +74,8 @@ public class CTstitch {
 						if (file2.exists()) System.err.println("Warning, file exists (skipping); "+newSession);
 						else {
 							if(file.renameTo(file2)) {
-								priorTime = 1 + (long)(ctr.newTime(newSession)*1000.);	// newest time from renamed source (sec -> msec)
+								// JPW, change from using newSession to priorTime (ie, use relative path, not including root folder)
+								priorTime = 1 + (long)(ctr.newTime(Long.toString(priorTime))*1000.);	// newest time from renamed source (sec -> msec)
 							}
 							else		throw new IOException("Failed to rename: "+sessionPath+" to: "+newSession);
 						}

--- a/JavaCode/CTlib/src/main/java/cycronix/ctlib/CTreader.java
+++ b/JavaCode/CTlib/src/main/java/cycronix/ctlib/CTreader.java
@@ -112,22 +112,30 @@ public class CTreader {
 //---------------------------------------------------------------------------------	
 // oldTime:  find oldest time for this source (neglects block-duration)
 	
-	// NOTE:  this takes full-path (ignores CTreader rootFolder)
+	// NOTE: sourceFolder is NOT full path (ie, isn't prepended by rootFolder)
 	public double oldTime(String sourceFolder) {
 		return oldTime(sourceFolder, (CTmap)null);
 	}
 	
+	// NOTE: sourceFolder is NOT full path (ie, isn't prepended by rootFolder)
 	public double oldTime(String sourceFolder, String chan) {
 		return oldTime(sourceFolder, new CTmap(chan));
 	}
 	
+	// NOTE: sourceFolder is NOT full path (ie, isn't prepended by rootFolder)
+	//       in this method we prepend sourceFolder with rootFolder (if it is defined)
 	public double oldTime(String sourceFolder, CTmap ctmap) {
-		CTFile rootfolder = new CTFile(sourceFolder);
+		String sourceFolder_fullpath = sourceFolder;
+		if (rootFolder != null) {
+			sourceFolder_fullpath = new String(rootFolder + File.separator + sourceFolder);
+		}
+		CTFile rootfolder = new CTFile(sourceFolder_fullpath);
 		CTFile[] listOfFolders = rootfolder.listFiles();
 		if(listOfFolders == null) return 0.;
 		return oldTime(listOfFolders, ctmap);
 	}
 	
+	// NOTE: Each folder in listOfFolders should already be prepended with the rootFolder
 	private double oldTime(CTFile[] listOfFolders, CTmap ctmap) {
 		if(listOfFolders == null) return 0.;
 
@@ -158,22 +166,30 @@ public class CTreader {
 // newTime:  find newest time for this source	(neglects block-duration)
 //	CTFile newFile = null;
 	
-	// NOTE:  this takes full-path (ignores CTreader rootFolder)
+	// NOTE: sourceFolder is NOT full path (ie, isn't prepended by rootFolder)
 	public double newTime(String sourceFolder) {
 		return newTime(sourceFolder, (CTmap)null);
 	}
 	
+	// NOTE: sourceFolder is NOT full path (ie, isn't prepended by rootFolder)
 	public double newTime(String sourceFolder, String chan) {
 		return newTime(sourceFolder, new CTmap(chan));
 	}
 	
+	// NOTE: sourceFolder is NOT full path (ie, isn't prepended by rootFolder)
+	//       in this method we prepend sourceFolder with rootFolder (if it is defined)
  	public double newTime(String sourceFolder, CTmap ctmap) {
-		CTFile rootfolder = new CTFile(sourceFolder);
+ 		String sourceFolder_fullpath = sourceFolder;
+		if (rootFolder != null) {
+			sourceFolder_fullpath = new String(rootFolder + File.separator + sourceFolder);
+		}
+		CTFile rootfolder = new CTFile(sourceFolder_fullpath);
 		CTFile[] listOfFolders = rootfolder.listFiles();
 		if(listOfFolders == null) return 0.;
 		return(newTime(listOfFolders, ctmap));
 	}
 	
+ 	// NOTE: Each folder in listOfFolders should already be prepended with the rootFolder
 	private double newTime(CTFile[] listOfFolders, CTmap ctmap) {
 		if(listOfFolders == null) return 0.;
 

--- a/JavaCode/CTlogger/src/main/java/ctlogger/CTlogger.java
+++ b/JavaCode/CTlogger/src/main/java/ctlogger/CTlogger.java
@@ -319,7 +319,8 @@ public class CTlogger {
 				
 				if(appendMode) {
 					ctreader = new CTreader(CTrootfolder);
-					appendTime = (long)(ctreader.newTime(sourceFolder) * 1000);	 // convert sec to msec
+					// JPW, change from sourceFolder to SourceName (ie, not full path)
+					appendTime = (long)(ctreader.newTime(SourceName) * 1000);	 // convert sec to msec
 					if(debug) System.err.println("appending past time: "+appendTime);
 				}
 				ctw.setDebug(debug);

--- a/JavaCode/CTpack/src/main/java/ctpack/CTpack.java
+++ b/JavaCode/CTpack/src/main/java/ctpack/CTpack.java
@@ -82,15 +82,17 @@ public class CTpack {
 			if(sources.size() == 0) System.err.println("Warning:  no sources found in rootFolder: "+rootFolder);
 			for(String source:sources) {							// {Loop by Source}
 				String sourcePath = rootFolder + File.separator + source;
-				double oldTime = ctr.oldTime(sourcePath);		// go absolute time oldest to newest (straddling gaps)
-				double newTime = ctr.newTime(sourcePath);
+				// JPW, in next 2 calls, changed sourcePath to source (ie, don't use full path)
+				double oldTime = ctr.oldTime(source);		// go absolute time oldest to newest (straddling gaps)
+				double newTime = ctr.newTime(source);
 				System.err.println("Source: "+source+", oldTime: "+oldTime+", newTime: "+newTime);
 
 				if(singleFolder) {			// crop time to LCD of all chans
 					for(String chan:ctr.listChans(source)) {
-						double thisTime = ctr.oldTime(sourcePath,chan);
+						// JPW, in calls to oldTime and newTime, changed sourcePath to source (ie, don't use full path)
+						double thisTime = ctr.oldTime(source,chan);
 						if(thisTime > oldTime) oldTime = thisTime;
-						thisTime = ctr.newTime(sourcePath,chan);
+						thisTime = ctr.newTime(source,chan);
 						if(thisTime < newTime) newTime = thisTime;
 						timePerBlock = newTime - oldTime;			// single fetch
 					}

--- a/JavaCode/CTplugin/src/main/java/ctplugin/CTplugin.java
+++ b/JavaCode/CTplugin/src/main/java/ctplugin/CTplugin.java
@@ -219,9 +219,9 @@ public class CTplugin {
 
 			try{ 
 				if ( ((picm.GetName(0).equals("...")) || (picm.GetName(0).equals("*"))) ) {
-
-					double otime=ctreader.oldTime(sourceFolder); 
-					double ntime=ctreader.newTime(sourceFolder);
+					// JPW, in next 2 calls, change sourceFolder to sName (ie, don't use full path)
+					double otime=ctreader.oldTime(sName); 
+					double ntime=ctreader.newTime(sName);
 					if(debug) System.err.println("handleRegistration picm[0]: "+picm.GetName(0)+", oldtime: "+otime+", newtime: "+ntime);
 
 					picm.PutTime(otime, ntime-otime);
@@ -249,8 +249,9 @@ public class CTplugin {
 					}
 				} else {
 					CTmap ctmap = PI2CTmap(picm);								// ignore time limits registration request
-					double otime=ctreader.oldTime(sourceFolder,ctmap); 
-					double ntime=ctreader.newTime(sourceFolder,ctmap);
+					// JPW, in next 2 calls, change sourceFolder to sName (ie, don't use full path)
+					double otime=ctreader.oldTime(sName,ctmap); 
+					double ntime=ctreader.newTime(sName,ctmap);
 					picm.PutTime(otime, ntime-otime);
 					if(debug) System.err.println("handleRegistration picm[0]: "+picm.GetName(0)+", oldtime: "+otime+", newtime: "+ntime);
 				

--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/CTscreencap.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/CTscreencap.java
@@ -542,7 +542,9 @@ public class CTscreencap implements ActionListener,ChangeListener,MouseMotionLis
 					// MJM 2017-02-23
 					// Pickup at 1msec after the last timestamp observed in the output source folders;
 					// this avoids a problem if user has manually deleted/changed CT disk folders
-					firstCTtime = 1 + (long)((new CTreader().newTime(outputFolder + sourceName)) * 1000.);
+					// JPW, changed to not use full path in newTime call
+					// firstCTtime = 1 + (long)((new CTreader().newTime(outputFolder + sourceName)) * 1000.);
+					firstCTtime = 1 + (long)((new CTreader(outputFolder).newTime(sourceName)) * 1000.);
 				}
 				// Note the current wall clock time
 				continueWallclockInitTime = System.currentTimeMillis();

--- a/JavaCode/CTweb/src/main/java/ctweb/CTweb.java
+++ b/JavaCode/CTweb/src/main/java/ctweb/CTweb.java
@@ -464,8 +464,9 @@ public class CTweb {
         								if(debug) System.err.println("NOT_MODIFIED: "+matchchan+", reqTime: "+start+", gotTime: "+gottime+", ref: "+reference);
 
         	   							// add header info about time limits
-            							double oldTime = ctreader.oldTime(sourcePath,chan);
-            							double newTime = ctreader.newTime(sourcePath,chan);
+        								// JPW, in next 2 calls, change from sourcePath to source (ie, don't use full path)
+            							double oldTime = ctreader.oldTime(source,chan);
+            							double newTime = ctreader.newTime(source,chan);
             							double lagTime = ((double)System.currentTimeMillis()/1000.) - newTime;
         								formHeader(response, time[0], time[time.length-1], oldTime, newTime, lagTime);
         								
@@ -496,8 +497,9 @@ public class CTweb {
     							byte[] bdata = tdata.getDataAsByteArray();		// get as single byte array vs chunks
 
 	   							// add header info about time limits
-    							double oldTime = ctreader.oldTime(sourcePath,chan);
-    							double newTime = ctreader.newTime(sourcePath,chan);
+    							// JPW, in next 2 calls, change from sourcePath to source (ie, don't use full path)
+    							double oldTime = ctreader.oldTime(source,chan);
+    							double newTime = ctreader.newTime(source,chan);
     							double lagTime = ((double)System.currentTimeMillis()/1000.) - newTime;
 								formHeader(response, time[0], time[time.length-1], oldTime, newTime, lagTime);
     						
@@ -577,8 +579,9 @@ public class CTweb {
     								}
     							}
     							// add header info about time limits
-    							oldTime = ctreader.oldTime(sourcePath,chan);
-    							newTime = ctreader.newTime(sourcePath,chan);
+    							// JPW, in next 2 calls, change from sourcePath to source (ie, don't use full path)
+    							oldTime = ctreader.oldTime(source,chan);
+    							newTime = ctreader.newTime(source,chan);
     							lagTime = ((double)System.currentTimeMillis()/1000.) - newTime;
     							formHeader(response, time[0], time[time.length-1], oldTime, newTime, lagTime);  
     							//    								response.setContentType(mimeType(pathInfo, "text/html"));
@@ -590,8 +593,9 @@ public class CTweb {
     					else {
     						// add header info about time limits even if no data
     						if(debug) System.err.println("No data for: "+pathInfo);
-    						double oldTime = ctreader.oldTime(sourcePath,chan);
-    						double newTime = ctreader.newTime(sourcePath,chan);
+    						// JPW, in next 2 calls, change from sourcePath to source (ie, don't use full path)
+    						double oldTime = ctreader.oldTime(source,chan);
+    						double newTime = ctreader.newTime(source,chan);
     						double lagTime = ((double)System.currentTimeMillis()/1000.) - newTime;
     						formHeader(response, start, duration, oldTime, newTime, lagTime);
         					formResponse(response, null);		// add CORS header even for error response


### PR DESCRIPTION
the public oldTime and newTime methods now take a *relative* path rather than an absolute path; the base or root path should already be known by CTreader