### PR TITLE
CTscreencap changes to support the new preview window and webcam capture

### DIFF
--- a/JavaCode/.gitignore
+++ b/JavaCode/.gitignore
@@ -1,2 +1,2 @@
 Distribute/
-
+.idea/

--- a/JavaCode/CTscreencap/build.gradle
+++ b/JavaCode/CTscreencap/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'
     compile group: 'com.github.sarxos', name: 'webcam-capture', version: '0.3.11+'
     compile group: 'org.openimaj', name: 'openimaj', version: '1.3.5+'
+    compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.8+'
 }
 
 

--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/DisplayImage.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/DisplayImage.java
@@ -2,31 +2,42 @@
 
 package erigo.ctscreencap;
 
-import java.awt.FlowLayout;
+import java.awt.*;
 import java.awt.image.BufferedImage;
-import javax.swing.ImageIcon;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
+import javax.swing.*;
 
 public class DisplayImage {
 
-	JLabel lbl=null;
-	JFrame frame=null;
+	public JFrame frame = null;
+	private JLabel lbl = null;
 
-	public DisplayImage(String title) 
+	public DisplayImage(String title, Dimension initSize)
 	{
-		frame=new JFrame();
-		frame.setTitle(title);
-		frame.setLayout(new FlowLayout());
-//		frame.setSize(width,height);
-		lbl = new JLabel();
-		frame.add(lbl);
-		frame.setVisible(true);
-		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		// For thread safety: Schedule a job for the event-dispatching thread to create and show the GUI
+		SwingUtilities.invokeLater(new Runnable() {
+			public void run() {
+				frame = new JFrame();
+				frame.setTitle(title);
+				lbl = new JLabel();
+				JScrollPane scrollPane = new JScrollPane(lbl);
+				scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+				scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+				frame.add(scrollPane,BorderLayout.CENTER);
+				frame.setVisible(true);
+				frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+				frame.setSize(initSize);
+			}
+		});
 	}
 
 	public void updateImage(BufferedImage img, int width, int height) {
-		frame.setSize(width,height);
-		lbl.setIcon(new ImageIcon(img));
+		// For thread safety: Schedule a job for the event-dispatching thread to update the image on the JLabel
+		SwingUtilities.invokeLater(new Runnable() {
+			public void run() {
+				lbl.setSize(width, height);
+				lbl.setIcon(new ImageIcon(img));
+				lbl.repaint();
+			}
+		});
 	}
 }

--- a/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/ScreencapTimerTask.java
+++ b/JavaCode/CTscreencap/src/main/java/erigo/ctscreencap/ScreencapTimerTask.java
@@ -60,7 +60,7 @@ public class ScreencapTimerTask extends TimerTask {
 		if (cts.bShutdown) {
 			return;
 		}
-		if (!cts.bFullScreen) {
+		if (!cts.bFullScreen  && !cts.bWebCam) {
 			// User will specify the region to capture via the JFame
 			// If the JFrame is not yet up, just return
 			if ( (cts.guiFrame == null) || (!cts.guiFrame.isShowing()) ) {


### PR DESCRIPTION
o put the preview image in a scrollpane; this way, the window doesn’t need to be expanded to full view in order to see everything

o graphics calls in DisplayImage are now called using SwingUtilities.invokeLater() for thread safety

o if user is previewing the webcam image, don’t display the screen capture region box – ie, only display the controls panel; disable resizing of the controls panel, but moving is still supported

o add “Preview” checkbox to the controls panel; center the frames/sec selection and image quality slider in the controls panel

o if user is previewing the webcam image, set the initial size of the preview window to view the entire webcam image

o get rid of the slf4j logging warning at startup by including “slf4j-nop.jar” in the build

o integrate open/close of the Webcam object into CTscreencap.startCapture() and CTscreencap.stopCapture()
