### PR TITLE
CTstream tweaks

### DIFF
--- a/JavaCode/CTstream/src/main/java/erigo/ctstream/PreviewWindow.java
+++ b/JavaCode/CTstream/src/main/java/erigo/ctstream/PreviewWindow.java
@@ -151,7 +151,15 @@ public class PreviewWindow {
 			System.err.println("ERROR: preview window not setup for plot");
 			return;
 		}
-		XYDataset dataset = createDataset(xDataI,yDataI);
+		if ( (xDataI == null) || xDataI.isEmpty() || (yDataI == null) || yDataI.isEmpty() ) {
+			System.err.println("Updating preview plot: empty x and/or y data, no data to display");
+			return;
+		}
+		XYDataset dataset = createDataset(xDataI, yDataI);
+		if (chart == null) {
+			System.err.println("Updating preview plot: chart is currently null (probably a startup transient)");
+			return;
+		}
 		chart.getXYPlot().setDataset(dataset);
 		if (bMakeSymmetricI) {
 			// Adjust the y-axis (Range) limits

--- a/JavaCode/CTstream/src/main/java/erigo/ctstream/WebcamStream.java
+++ b/JavaCode/CTstream/src/main/java/erigo/ctstream/WebcamStream.java
@@ -52,9 +52,9 @@ public class WebcamStream extends DataStream {
     private Timer webcamTimer = null;			    // Periodic Timer object
     private ImageTimerTask webcamTimerTask = null;	// TimerTask executed each time the periodic Timer expires
     public long capturePeriodMillis;                // capture period in milliseconds
-//    public static Webcam webcam = null;             // webcam object to grab images from
-    public static Video<MBFImage> webcam = null;             // webcam object to grab images from
-    static Dimension previewSize = new Dimension(640, 480);
+    // public static Webcam webcam = null;          // webcam object to grab images from
+    public static Video<MBFImage> webcam = null;    // webcam object to grab images from
+    private final static Dimension IMAGE_SIZE = new Dimension(640, 480);
     
     /**
      * WebcamStream constructor
@@ -123,9 +123,7 @@ public class WebcamStream extends DataStream {
         if (bPreview && bIsRunning && cts.bPreview && (webcam != null) /* && webcam.isOpen() */) {
             // Set the size of the preview window to match the image size plus some extra padding
             // so scrollbars aren't needed
-//            Dimension previewSize = webcam.getViewSize();
-            previewSize = new Dimension(previewSize.width+25,previewSize.height+55);
-            previewWindow.setFrameSize(previewSize);
+            previewWindow.setFrameSize(new Dimension(IMAGE_SIZE.width+25,IMAGE_SIZE.height+55));
         }
     }
 
@@ -163,11 +161,10 @@ public class WebcamStream extends DataStream {
     private static void openWebCamera() throws Exception {
         if (webcam == null) {
             System.err.println("\nOpen web camera");
-//            webcam = Webcam.getDefault();
-//            webcam.setViewSize(WebcamResolution.VGA.getSize());
-//            webcam.open();
-//            webcam = new VideoCapture(previewSize.width, previewSize.height);
-            webcam = new VideoCapture(640, 480);
+            // webcam = Webcam.getDefault();
+            // webcam.setViewSize(WebcamResolution.VGA.getSize());
+            // webcam.open();
+            webcam = new VideoCapture(IMAGE_SIZE.width, IMAGE_SIZE.height);
         }
     }
 


### PR DESCRIPTION
(a) add a check in PreviewWindow to take care of a null pointer exception that would occasionally occur just after popping up a plot preview window, resulting in all data streams to stop sending data to CT

(b) fix minor problem with the size of webcam preview window (inadvertent side affect of the prior change to webcam logic, the webcam preview window would grow in size every time the preview windows were popped down and then brought back up again)