### PR TITLE
Tweaks to JavaCode build system

### DIFF
--- a/JavaCode/build.gradle
+++ b/JavaCode/build.gradle
@@ -43,7 +43,8 @@ subprojects {
     compileJava.mustRunAfter clean
     
     // Copy the JAR file to a top level "Distribute" folder; do this last 
-    // so we make sure to get the newly built JAR file
+    // so we make sure to get the newly built JAR file.
+    // Also at the end of any build, copy LICENSE and NOTICE over to Distribute.
     build.doLast {
     	task -> println "Built $task.project.name"
     	String fromLoc = "${buildDir}/libs/" + project.name + ".jar"
@@ -52,6 +53,11 @@ subprojects {
     		from fromLoc
     		into toLoc
     	}
+        println "Copy LICENSE and NOTICE files to Distribute folder."
+        copy {
+            from "$rootDir/../LICENSE", "$rootDir/../NOTICE"
+            into "$rootDir/Distribute"
+        }
     }
     
     // Javadoc specifications

--- a/JavaCode/settings.gradle
+++ b/JavaCode/settings.gradle
@@ -1,2 +1,2 @@
-// The following sub-projects are not built by default: CTjms, FileWatch (FileWatch is not built because it uses an LGPL library, JFreeChart)
-include 'CT2CSV','CTadmin','CTarchive','CTaudio','CTblocktest','CTexample','CTlib','CTlogger','CTmetrics','CTpack','CTplugin','CTserial','CTstream','CTsync','CTtext','CTudp','CTweb','FilePump'
+// The following sub-projects are not built by default: CTjms, FilePump, FileWatch; we don't want to build/distribute FileWatch because it uses an LGPL library, JFreeChart
+include 'CT2CSV','CTadmin','CTarchive','CTaudio','CTblocktest','CTexample','CTlib','CTlogger','CTmetrics','CTpack','CTplugin','CTserial','CTstream','CTsync','CTtext','CTudp','CTweb'


### PR DESCRIPTION
(1) copy LICENSE and NOTICE files to Distribute folder

(2) no longer build FilePump by default
